### PR TITLE
🎨 Destructure props in SettingsModal.js

### DIFF
--- a/renderer/components/dashboard/settings/SettingsModal.js
+++ b/renderer/components/dashboard/settings/SettingsModal.js
@@ -6,6 +6,8 @@ export default function SettingsModal(props) {
   const [settings, setSettings] = useSettings();
   let checked = false;
 
+  const { show, onHide } = props;
+
   if (settings?.checked) {
     checked = settings.checked === "false" ? false : true;
   }
@@ -31,8 +33,8 @@ export default function SettingsModal(props) {
 
   return (
     <Modal
-      show={props.show}
-      onHide={props.onHide}
+      show={show}
+      onHide={onHide}
       size="lg"
       aria-labelledby="contained-modal-title-vcenter"
     >
@@ -115,7 +117,7 @@ export default function SettingsModal(props) {
         </Form>
       </Modal.Body>
       <Modal.Footer className="d-flex flex-row justify-content-between">
-        <Button onClick={props.onHide}>Close</Button>
+        <Button onClick={onHide}>Close</Button>
         <Button onClick={saveSettings} variant="success" className="mt-3">
           Save
         </Button>


### PR DESCRIPTION
fixes #16 

Destructured the props to extract show and onHide functions.